### PR TITLE
Fix Timestamp Formatting

### DIFF
--- a/deepChannel/kotnPushSavedSearch.ts
+++ b/deepChannel/kotnPushSavedSearch.ts
@@ -17,7 +17,7 @@ import * as s3Push from './kotnHandleS3Push';
 
 function makeTS(d){
 	var d = d || new Date();
-	return d.toISOString().replace(/.\.\d+/, '').replace(/[-:]/g, '');
+	return d.toISOString().replace(/\.\d+/, '').replace(/[-:]/g, '');
 }
 
 function escapeCSV(val){
@@ -92,9 +92,9 @@ export function execute(ctx){
 				var nextParentId = null;
 				search.create({
 					type:'folder',
-					filters:filters, 
+					filters:filters,
 					columns:[
-						'name', 
+						'name',
 						'parent'
 					]
 				}).run().each(f=>{


### PR DESCRIPTION
Timestamps were previously exported like so:

    20200902T02031Z

Note however that the time component is expressed as '02031Z', which
oddly includes the tens digits of the seconds but not the ones digit,
making this timestamp unparseable automatically by the likes of Ruby's
`Time.parse`.

This edit modifies the regex to not capture the seconds ones digit,
causing the following to be generated as the timezone.

    20200902T020319Z